### PR TITLE
Fix old map utilities for Python 3

### DIFF
--- a/gfx.py
+++ b/gfx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """Supplementary scripts for graphics conversion."""
 

--- a/tools/gfx.py
+++ b/tools/gfx.py
@@ -2,19 +2,19 @@
 
 import os
 import sys
-import png
+from . import png
 from math import sqrt, floor, ceil
 import argparse
 import operator
 
-from lz import Compressed, Decompressed
+from .lz import Compressed, Decompressed
 
 
 def split(list_, interval):
     """
     Split a list by length.
     """
-    for i in xrange(0, len(list_), interval):
+    for i in range(0, len(list_), interval):
         j = min(i + interval, len(list_))
         yield list_[i:j]
 
@@ -66,7 +66,7 @@ def transpose(tiles, width=None):
     """
     if width == None:
         width = int(sqrt(len(tiles))) # assume square image
-    tiles = sorted(enumerate(tiles), key= lambda (i, tile): i % width)
+    tiles = sorted(enumerate(tiles), key=lambda it: it[0] % width)
     return [tile for i, tile in tiles]
 
 def transpose_tiles(image, width=None):
@@ -244,7 +244,7 @@ def flatten(planar):
         bottom = bottom
         top = top
         strip = []
-        for i in xrange(7,-1,-1):
+        for i in range(7,-1,-1):
             color = (
                 (bottom >> i & 1) +
                 (top *2 >> i & 2)
@@ -259,14 +259,14 @@ def to_lines(image, width):
     """
     tile_width = 8
     tile_height = 8
-    num_columns = width / tile_width
-    height = len(image) / width
+    num_columns = width // tile_width
+    height = len(image) // width
 
     lines = []
-    for cur_line in xrange(height):
-        tile_row = cur_line / tile_height
+    for cur_line in range(height):
+        tile_row = cur_line // tile_height
         line = []
-        for column in xrange(num_columns):
+        for column in range(num_columns):
             anchor = (
                 num_columns * tile_row * tile_width * tile_height +
                 column * tile_width * tile_height +
@@ -287,7 +287,7 @@ def dmg2rgb(word):
             value >>= 5
     word = shift(word)
     # distribution is less even w/ << 3
-    red, green, blue = [int(color * 8.25) for color in [word.next() for _ in xrange(3)]]
+    red, green, blue = [int(color * 8.25) for color in [next(word) for _ in range(3)]]
     alpha = 255
     return (red, green, blue, alpha)
 
@@ -296,9 +296,9 @@ def rgb_to_dmg(color):
     """
     For PNGs.
     """
-    word =  (color['r'] / 8)
-    word += (color['g'] / 8) << 5
-    word += (color['b'] / 8) << 10
+    word =  (color['r'] // 8)
+    word += (color['g'] // 8) << 5
+    word += (color['b'] // 8) << 10
     return word
 
 
@@ -329,7 +329,7 @@ def png_to_rgb(palette):
     """
     output = ''
     for color in palette:
-        r, g, b = [color[c] / 8 for c in 'rgb']
+        r, g, b = [color[c] // 8 for c in 'rgb']
         output += '\tRGB ' + ', '.join(['%.2d' % hue for hue in (r, g, b)])
         output += '\n'
     return output
@@ -431,7 +431,7 @@ def convert_2bpp_to_png(image, **kwargs):
 
     # Width must be specified to interleave.
     if interleave and width:
-        image = interleave_tiles(image, width / 8)
+        image = interleave_tiles(image, width // 8)
 
     # Pad the image by a given number of tiles if asked.
     image += pad_color * 0x10 * tile_padding
@@ -446,34 +446,34 @@ def convert_2bpp_to_png(image, **kwargs):
         trailing = len(image) % pic_length
 
         pic = []
-        for i in xrange(0, len(image) - trailing, pic_length):
+        for i in range(0, len(image) - trailing, pic_length):
             pic += transpose_tiles(image[i:i+pic_length], h)
         image = bytearray(pic) + image[len(image) - trailing:]
 
         # Pad out trailing lines.
-        image += pad_color * 0x10 * ((w - (len(image) / 0x10) % h) % w)
+        image += pad_color * 0x10 * ((w - (len(image) // 0x10) % h) % w)
 
     def px_length(img):
         return len(img) * 4
     def tile_length(img):
-        return len(img) * 4 / (8*8)
+        return len(img) * 4 // (8*8)
 
     if width and height:
-        tile_width = width / 8
+        tile_width = width // 8
         more_tile_padding = (tile_width - (tile_length(image) % tile_width or tile_width))
         image += pad_color * 0x10 * more_tile_padding
 
     elif width and not height:
-        tile_width = width / 8
+        tile_width = width // 8
         more_tile_padding = (tile_width - (tile_length(image) % tile_width or tile_width))
         image += pad_color * 0x10 * more_tile_padding
-        height = px_length(image) / width
+        height = px_length(image) // width
 
     elif height and not width:
-        tile_height = height / 8
+        tile_height = height // 8
         more_tile_padding = (tile_height - (tile_length(image) % tile_height or tile_height))
         image += pad_color * 0x10 * more_tile_padding
-        width = px_length(image) / height
+        width = px_length(image) // height
 
     # at least one dimension should be given
     if width * height != px_length(image):
@@ -481,15 +481,15 @@ def convert_2bpp_to_png(image, **kwargs):
         matches = []
         # Height need not be divisible by 8, but width must.
         # See pokered gfx/minimize_pic.1bpp.
-        for w in range(8, px_length(image) / 2 + 1, 8):
-            h = px_length(image) / w
+        for w in range(8, px_length(image) // 2 + 1, 8):
+            h = px_length(image) // w
             if w * h == px_length(image):
                 matches += [(w, h)]
         # go for the most square image
         if len(matches):
-            width, height = sorted(matches, key= lambda (w, h): (h % 8 != 0, w + h))[0] # favor height
+            width, height = sorted(matches, key=lambda wh: (wh[1] % 8 != 0, wh[0] + wh[1]))[0] # favor height
         else:
-            raise Exception, 'Image can\'t be divided into tiles (%d px)!' % (px_length(image))
+            raise Exception('Image can\'t be divided into tiles (%d px)!' % (px_length(image)))
         # correct tileset dimensions
         if kwargs.get('is_tileset', False) and not (width * height // 8) % 128:
             area = width * height
@@ -530,17 +530,16 @@ def get_pic_animation(tmap, w, h):
     base = frames.pop(0)
     bitmasks = []
 
-    for i in xrange(len(frames)):
+    for i in range(len(frames)):
         frame_text += '\tdw .frame{}\n'.format(i + 1)
 
     for i, frame in enumerate(frames):
-        bitmask = map(operator.ne, frame, base)
+        bitmask = list(map(operator.ne, frame, base))
         if bitmask not in bitmasks:
             bitmasks.append(bitmask)
         which_bitmask = bitmasks.index(bitmask)
 
-        mask = iter(bitmask)
-        masked_frame = filter(lambda _: mask.next(), frame)
+        masked_frame = [x for x, m in zip(frame, bitmask) if m]
 
         frame_text += '.frame{}\n'.format(i + 1)
         frame_text += '\tdb ${:02x} ; bitmask\n'.format(which_bitmask)
@@ -657,16 +656,16 @@ def png_to_2bpp(filein, **kwargs):
     palette = []
     for line in rgba:
         newline = []
-        for px in xrange(0, len(line), len_px):
+        for px in range(0, len(line), len_px):
             color = dict(zip('rgba', line[px:px+len_px]))
             if color not in palette:
                 if len(palette) < 4:
                     palette += [color]
                 else:
                     # TODO Find the nearest match
-                    print 'WARNING: %s: Color %s truncated to' % (filein, color),
+                    print('WARNING: %s: Color %s truncated to' % (filein, color))
                     color = sorted(palette, key=lambda x: sum(x.values()))[0]
-                    print color
+                    print(color)
             newline += [color]
         image += [newline]
 
@@ -709,15 +708,15 @@ def png_to_2bpp(filein, **kwargs):
     # Graphics are stored in tiles instead of lines
     tile_width  = 8
     tile_height = 8
-    num_columns = max(width, tile_width) / tile_width
-    num_rows = max(height, tile_height) / tile_height
+    num_columns = max(width, tile_width) // tile_width
+    num_rows = max(height, tile_height) // tile_height
     image = []
 
-    for row in xrange(num_rows):
-        for column in xrange(num_columns):
+    for row in range(num_rows):
+        for column in range(num_columns):
 
             # Split it up into strips to convert to planar data
-            for strip in xrange(min(tile_height, height)):
+            for strip in range(min(tile_height, height)):
                 anchor = (
                     row * num_columns * tile_width * tile_height +
                     column * tile_width +
@@ -727,7 +726,7 @@ def png_to_2bpp(filein, **kwargs):
                 bottom, top = 0, 0
                 for bit, quad in enumerate(line):
                     bottom += (quad & 1) << (7 - bit)
-                    top += (quad /2 & 1) << (7 - bit)
+                    top += (quad // 2 & 1) << (7 - bit)
                 image += [bottom, top]
 
     dim = arguments['pic_dimensions']
@@ -736,20 +735,20 @@ def png_to_2bpp(filein, **kwargs):
             w, h = dim
         else:
             # infer dimensions based on width.
-            w = width / tile_width
-            h = height / tile_height
+            w = width // tile_width
+            h = height // tile_height
             if h % w == 0:
                 h = w
 
         tiles = get_tiles(image)
         pic_length = w * h
-        tile_width = width / 8
+        tile_width = width // 8
         trailing = len(tiles) % pic_length
         new_image = []
-        for block in xrange(len(tiles) / pic_length):
-            offset = (h * tile_width) * ((block * w) / tile_width) + ((block * w) % tile_width)
+        for block in range(len(tiles) // pic_length):
+            offset = (h * tile_width) * ((block * w) // tile_width) + ((block * w) % tile_width)
             pic = []
-            for row in xrange(h):
+            for row in range(h):
                 index = offset + (row * tile_width)
                 pic += tiles[index:index + w]
             new_image += transpose(pic, w)
@@ -876,7 +875,7 @@ def convert_to_2bpp(filenames=[]):
         elif extension == '.png':
             export_png_to_2bpp(filename)
         else:
-            raise Exception, "Don't know how to convert {} to 2bpp!".format(filename)
+            raise Exception("Don't know how to convert {} to 2bpp!".format(filename))
 
 def convert_to_1bpp(filenames=[]):
     for filename in filenames:
@@ -888,7 +887,7 @@ def convert_to_1bpp(filenames=[]):
         elif extension == '.png':
             export_png_to_1bpp(filename)
         else:
-            raise Exception, "Don't know how to convert {} to 1bpp!".format(filename)
+            raise Exception("Don't know how to convert {} to 1bpp!".format(filename))
 
 def convert_to_png(filenames=[]):
     for filename in filenames:
@@ -900,7 +899,7 @@ def convert_to_png(filenames=[]):
         elif extension == '.png':
             pass
         else:
-            raise Exception, "Don't know how to convert {} to png!".format(filename)
+            raise Exception("Don't know how to convert {} to png!".format(filename))
 
 def compress(filenames=[]):
     for filename in filenames:
@@ -944,7 +943,7 @@ def main():
     }.get(args.mode, None)
 
     if method == None:
-        raise Exception, "Unknown conversion method!"
+        raise Exception("Unknown conversion method!")
 
     method(args.filenames)
 

--- a/tools/lz.py
+++ b/tools/lz.py
@@ -44,8 +44,8 @@ lz_end = 0xff
 
 
 bit_flipped = [
-    sum(((byte >> i) & 1) << (7 - i) for i in xrange(8))
-    for byte in xrange(0x100)
+    sum(((byte >> i) & 1) << (7 - i) for i in range(8))
+    for byte in range(0x100)
 ]
 
 
@@ -146,7 +146,7 @@ class Compressed:
         self.scores = {}
         self.offsets = {}
         self.helpers = {}
-        for method in self.min_scores.iterkeys():
+        for method in self.min_scores.keys():
             self.scores[method] = 0
 
     def bit_flip(self, byte):
@@ -163,7 +163,7 @@ class Compressed:
     def score(self):
         self.reset_scores()
 
-        map(self.score_literal, ['iterate', 'alternate', 'blank'])
+        list(map(self.score_literal, ['iterate', 'alternate', 'blank']))
 
         for method in self.lookback_methods:
             self.scores[method], self.offsets[method] = self.find_lookback(method, self.address)
@@ -173,7 +173,7 @@ class Compressed:
         return any(
             score
           > self.min_scores[method] + int(score > lowmax)
-            for method, score in self.scores.iteritems()
+            for method, score in self.scores.items()
         )
 
     def stop_short(self):
@@ -189,7 +189,7 @@ class Compressed:
         )
         for method in self.lookback_methods:
             min_score = self.min_scores[method]
-            for address in xrange(self.address+1, self.address+best_score):
+            for address in range(self.address+1, self.address+best_score):
                 length, index = self.find_lookback(method, address)
                 if length > max(min_score, best_score):
                     # BUG: lookbacks can reduce themselves. This appears to be a bug in the target also.
@@ -211,7 +211,7 @@ class Compressed:
 
     def find_lookback(self, method, address=None):
         """Temporarily stubbed, because the real function doesn't run in polynomial time."""
-	return 0, None
+        return 0, None
 
     def broken_find_lookback(self, method, address=None):
         if address is None:
@@ -314,16 +314,14 @@ class Compressed:
         self.helpers[method] = compare
 
     def do_winner(self):
-        winners = filter(
-            lambda (method, score):
-                score
-              > self.min_scores[method] + int(score > lowmax),
-            self.scores.iteritems()
-        )
+        winners = list(filter(
+            lambda ms: ms[1] > self.min_scores[ms[0]] + int(ms[1] > lowmax),
+            self.scores.items()
+        ))
         winners.sort(
-            key = lambda (method, score): (
-                -(score - self.min_scores[method] - int(score > lowmax)),
-                self.preference.index(method)
+            key = lambda ms: (
+                -(ms[1] - self.min_scores[ms[0]] - int(ms[1] > lowmax)),
+                self.preference.index(ms[0])
             )
         )
         winner, score = winners[0]
@@ -365,14 +363,14 @@ class Compressed:
                 offset = (start_address - offset - 1) | 0x80
                 output += [offset]
             else:
-                output += [offset / 0x100, offset % 0x100] # big endian
+                output += [offset // 0x100, offset % 0x100] # big endian
 
         if self.debug:
-            print ' '.join(map(str, [
+            print(' '.join(map(str, [
                   cmd, length, '\t',
                   ' '.join(map('{:02x}'.format, output)),
                   self.data[start_address:start_address+length] if cmd in self.lookback_methods else '',
-            ]))
+            ])))
 
         self.output += output
 
@@ -414,7 +412,8 @@ class Decompressed:
         if self.lz is not None:
             self.decompress()
 
-        if self.debug: print self.command_list()
+        if self.debug:
+            print(self.command_list())
 
 
     def command_list(self):
@@ -440,7 +439,7 @@ class Decompressed:
             if offset is not None:
                 repeated_data = self.output[ offset : offset + length * direction : direction ]
                 if name == 'flip':
-                    repeated_data = map(bit_flipped.__getitem__, repeated_data)
+                    repeated_data = list(map(bit_flipped.__getitem__, repeated_data))
                 text += ' [' + ' '.join(map('{:02x}'.format, repeated_data)) + ']'
 
             text += '\n'
@@ -543,7 +542,7 @@ class Decompressed:
         Write alternating bytes.
         """
         alts = [self.next(), self.next()]
-        self.output += [ alts[x & 1] for x in xrange(self.length) ]
+        self.output += [ alts[x & 1] for x in range(self.length) ]
 
     def blank(self):
         """
@@ -575,6 +574,6 @@ class Decompressed:
         self.get_offset()
         self.direction = direction
         # Note: appends must be one at a time (this way, repeats can draw from themselves if required)
-        for i in xrange(self.length):
+        for i in range(self.length):
             byte = self.output[ self.offset + i * direction ]
             self.output.append( table[byte] if table else byte )

--- a/utils/map-all.py
+++ b/utils/map-all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -98,7 +98,7 @@ def render_map_images(valid_tilesets):
 			block_data_name = map_block_data_exceptions.get(map_name, map_name)
 			if block_data_name in rendered:
 				continue
-			command = 'python utils/map.py %s %d %s' % (block_filename_fmt % block_data_name, map_width, tileset_name)
+			command = 'python3 utils/map.py %s %d %s' % (block_filename_fmt % block_data_name, map_width, tileset_name)
 			print()
 			print(command)
 			os.system(command)

--- a/utils/map.py
+++ b/utils/map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -13,12 +13,12 @@ import os.path
 import re
 import array
 
-from itertools import izip_longest
+from itertools import zip_longest
 
 import png
 
 def chunk(L, n, fillvalue=None):
-	return izip_longest(*[iter(L)] * n, fillvalue=fillvalue)
+        return zip_longest(*[iter(L)] * n, fillvalue=fillvalue)
 
 def rgb_bytes(rgbs):
 	for px in rgbs:
@@ -74,7 +74,6 @@ class Map(object):
 		self.data = []
 		with open(blockfile_name, 'rb') as blockfile:
 			for mti in blockfile.read():
-				mti = ord(mti)
 				self.data.append(metatiles.tile(mti))
 		if size.startswith('h'):
 			self.height = int(size[1:])
@@ -117,7 +116,7 @@ def main():
 	blockfile = sys.argv[1]
 	size = sys.argv[2]
 	tileset = sys.argv[3]
-	os.system('python utils/metatiles.py %s %s' % (tileset, blockfile))
+	os.system('python3 utils/metatiles.py %s %s' % (tileset, blockfile))
 	metatiles = 'data/tilesets/%s_metatiles.png' % tileset
 
 	process(blockfile, size, metatiles)

--- a/utils/metatiles.py
+++ b/utils/metatiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -14,12 +14,12 @@ import os.path
 import re
 import array
 
-from itertools import izip_longest
+from itertools import zip_longest
 
 import png
 
 def chunk(L, n, fillvalue=None):
-	return izip_longest(*[iter(L)] * n, fillvalue=fillvalue)
+        return zip_longest(*[iter(L)] * n, fillvalue=fillvalue)
 
 def rgb_bytes(rgbs):
 	for px in rgbs:
@@ -247,11 +247,11 @@ class Attributes(object):
 		assert len(self.colors) == 8
 		self.data = []
 		with open(filename, 'rb') as file:
-			while True:
-				tile_attrs = [ord(c) for c in file.read(Metatiles.t_per_m**2)]
-				if not len(tile_attrs):
-					break
-				self.data.append(tile_attrs)
+                        while True:
+                                tile_attrs = list(file.read(Metatiles.t_per_m**2))
+                                if not len(tile_attrs):
+                                        break
+                                self.data.append(tile_attrs)
 
 	def color4(self, i):
 		return self.colors[self.data[i]] if i < len(self.data) else [default_rgb] * 4
@@ -266,7 +266,7 @@ class Metatiles(object):
 		with open(filename, 'rb') as file:
 			i = 0
 			while True:
-				tile_indexes = [ord(c) for c in file.read(Metatiles.t_per_m**2)]
+				tile_indexes = list(file.read(Metatiles.t_per_m**2))
 				if not len(tile_indexes):
 					break
 				attr_indexes = self.attributes.data[i]


### PR DESCRIPTION
## Summary
- update `map-all.py`, `map.py` and `metatiles.py` for Python3
- modernize `gfx.py` helper and the graphics tools package
- tweak LZ utilities for Python3

## Testing
- `python3 gfx.py -h`
- `python3 utils/map-all.py x`
- `python3 -m py_compile utils/map.py utils/metatiles.py utils/map-all.py gfx.py tools/gfx.py tools/lz.py`


------
https://chatgpt.com/codex/tasks/task_e_68794d6c4544832596d0f098319887fa